### PR TITLE
Fix MSWINDOWS define validation

### DIFF
--- a/Source/FB4D.Helpers.pas
+++ b/Source/FB4D.Helpers.pas
@@ -181,8 +181,10 @@ implementation
 
 uses
   System.Character,
-{$IF Defined(VCL)}
+{$IFDEF MSWINDOWS}
   WinAPI.Windows,
+{$ENDIF}
+{$IF Defined(VCL)}
   VCL.Forms,
 {$ELSEIF Defined(FMX)}
   FMX.Types,
@@ -353,7 +355,7 @@ begin
   {$ENDIF}
 {$ELSEIF Defined(VCL)}
   OutputDebugString(PChar(msg));
-{$ELSEIF MSWINDOWS}
+{$ELSEIF Defined(MSWINDOWS)}
   OutputDebugString(PChar(msg));
 {$ELSE}
   writeln(msg);


### PR DESCRIPTION
What was done?
---
Fixed validation of MSWINDOWS defines.

Why was it done?
---
When using `$ELSEIF` the check if MSWINDOWS was defined isn't performed properly, its necessary to use the `Defined()` method to check in these cases.