### PR TITLE
TRTDBListenerThread.ResParams fix

### DIFF
--- a/DUnitX/Authentication.pas
+++ b/DUnitX/Authentication.pas
@@ -79,13 +79,12 @@ implementation
 
 uses
   VCL.Forms,
-  FB4D.Configuration;
+  FB4D.Configuration,
+  Consts;
 
 {$I FBConfig.inc}
 
 const
-  cEMail = 'Integration.Tester@FB4D.org';
-  cPassword = 'It54623!';
   cDisplayName = 'The Tester';
   cPhotoURL = 'https://www.schneider-infosys.ch/img/Christoph.png';
 

--- a/DUnitX/Consts.pas
+++ b/DUnitX/Consts.pas
@@ -1,0 +1,11 @@
+unit Consts;
+
+interface
+
+const
+  cEMail = 'Integration.Tester@FB4D.org';
+  cPassword = 'It54623!';
+
+implementation
+
+end.

--- a/DUnitX/FB4D.IntegrationTests.dpr
+++ b/DUnitX/FB4D.IntegrationTests.dpr
@@ -41,7 +41,8 @@ uses
   FirestoreDB in 'FirestoreDB.pas',
   Authentication in 'Authentication.pas',
   FBHelpers in 'FBHelpers.pas',
-  Storage in 'Storage.pas';
+  Storage in 'Storage.pas',
+  Consts in 'Consts.pas';
 
 begin
 {$IFDEF TESTINSIGHT}

--- a/DUnitX/FB4D.IntegrationTests.dproj
+++ b/DUnitX/FB4D.IntegrationTests.dproj
@@ -156,6 +156,7 @@
         <DCCReference Include="Authentication.pas"/>
         <DCCReference Include="FBHelpers.pas"/>
         <DCCReference Include="Storage.pas"/>
+        <DCCReference Include="Consts.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/DUnitX/FBFunction.pas
+++ b/DUnitX/FBFunction.pas
@@ -59,13 +59,10 @@ implementation
 
 uses
   VCL.Forms,
-  FB4D.Configuration;
+  FB4D.Configuration,
+  Consts;
 
 {$I FBConfig.inc}
-
-const
-  cEMail = 'Integration.Tester@FB4D.org';
-  cPassword = 'It54623!';
 
 procedure UT_FBFunction.Setup;
 begin

--- a/DUnitX/FirestoreDB.pas
+++ b/DUnitX/FirestoreDB.pas
@@ -73,13 +73,14 @@ implementation
 
 uses
   VCL.Forms,
-  FB4D.Configuration, FB4D.Helpers, FB4D.Document;
+  FB4D.Configuration,
+  FB4D.Helpers,
+  FB4D.Document,
+  Consts;
 
 {$I FBConfig.inc}
 
 const
-  cEMail = 'Integration.Tester@FB4D.org';
-  cPassword = 'It54623!';
   cDBPath = 'TestNode';
   cTestF1 = 'TestField1';
   cTestF2 = 'testField2';

--- a/DUnitX/RealTimeDB.pas
+++ b/DUnitX/RealTimeDB.pas
@@ -63,13 +63,12 @@ implementation
 
 uses
   VCL.Forms,
-  FB4D.Configuration;
+  FB4D.Configuration,
+  Consts;
 
 {$I FBConfig.inc}
 
 const
-  cEMail = 'Integration.Tester@FB4D.org';
-  cPassword = 'It54623!';
   cDBPath: TRequestResourceParam = ['TestNode', '1234'];
 
 { UT_RealTimeDB }

--- a/DUnitX/RealTimeDB.pas
+++ b/DUnitX/RealTimeDB.pas
@@ -42,8 +42,11 @@ type
     fData: TJSONObject;
     fCallBack: boolean;
     fRes: TJSONValue;
+    fFirebaseEvent: IFirebaseEvent;
     procedure OnPutGet(ResourceParams: TRequestResourceParam; Val: TJSONValue);
     procedure OnError(const RequestID, ErrMsg: string);
+    procedure OnReceive(const Event: string; Params: TRequestResourceParam; JSONObj: TJSONObject);
+    procedure OnStop(Sender: TObject);
   public
     [Setup]
     procedure Setup;
@@ -53,6 +56,7 @@ type
     [TestCase]
     procedure PutGetSynchronous;
     procedure PutGet;
+    procedure GetResourceParamListener;
   end;
 
 implementation
@@ -83,10 +87,51 @@ end;
 
 procedure UT_RealTimeDB.TearDown;
 begin
+  if Assigned(fFirebaseEvent) and (not fFirebaseEvent.IsStopped) then
+    fFirebaseEvent.StopListening;
+
   fConfig.RealTimeDB.DeleteSynchronous(cDBPath);
   fData.Free;
   fConfig.Auth.DeleteCurrentUserSynchronous;
   fConfig := nil;
+end;
+
+procedure UT_RealTimeDB.GetResourceParamListener;
+var
+  Res: TJSONValue;
+  DBPath: string;
+  ResourcePath: string;
+begin
+  Status('Put single value');
+  fData.AddPair('Item1', 'TestVal1');
+  Res := fConfig.RealTimeDB.PutSynchronous(cDBPath, fData);
+  Assert.IsNotNull(res, 'Result of Put is nil');
+  Assert.AreEqual(fData.ToJSON, Res.ToJSON,
+    'result JSON is different from put');
+  Res.Free;
+
+  Status('Listen value');
+  fFirebaseEvent := fConfig.RealTimeDB.ListenForValueEvents(cDBPath,
+    OnReceive, OnStop, OnError);
+
+  sleep(1); //give time to the thread create fAsyncResult object
+
+  Assert.IsNotNull(fFirebaseEvent.GetResourceParams);
+  ResourcePath := string.Join('/', fFirebaseEvent.GetResourceParams);
+  DbPath := string.Join('/', cDBPath);
+  Assert.AreEqual(DBPath, ResourcePath,
+    'ResourceParams is different from the listened');
+end;
+
+procedure UT_RealTimeDB.OnReceive(const Event: string; Params:
+  TRequestResourceParam; JSONObj: TJSONObject);
+begin
+  fCallBack := true;
+end;
+
+procedure UT_RealTimeDB.OnStop(Sender: TObject);
+begin
+
 end;
 
 procedure UT_RealTimeDB.OnError(const RequestID, ErrMsg: string);

--- a/Source/FB4D.RealTimeDB.Listener.pas
+++ b/Source/FB4D.RealTimeDB.Listener.pas
@@ -150,9 +150,10 @@ procedure TRTDBListenerThread.RegisterEvents(ResParams: TRequestResourceParam;
   OnConnectionStateChange: TOnConnectionStateChange;
   DoNotSynchronizeEvents: boolean);
 begin
-  fURL := fBaseURL + TFirebaseHelpers.EncodeResourceParams(ResParams) +
+  fResParams := ResParams;
+  fURL := fBaseURL + TFirebaseHelpers.EncodeResourceParams(fResParams) +
     cJSONExt;
-  fRequestID :=  TFirebaseHelpers.ArrStrToCommaStr(ResParams);
+  fRequestID :=  TFirebaseHelpers.ArrStrToCommaStr(fResParams);
   fOnListenEvent := OnListenEvent;
   fOnStopListening := OnStopListening;
   fOnListenError := OnError;


### PR DESCRIPTION
What was done?
---
Fixed the value assignment of the `fResParams` variable of the `TRTDBListenerThread` class.

Why was this done?
---
In the `RegisterEvents` method the value of `ResParams` was not being saved correctly in the variable `fResParams`.