### PR TITLE
Add support for BOSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ __recovery/
 
 # Castalia statistics file (since XE7 Castalia is distributed with Delphi)
 *.stat
+#Boss Dependency Manager for Delphi and Lazarus (Windows)
+modules/

--- a/boss.json
+++ b/boss.json
@@ -6,6 +6,6 @@
 	"mainsrc": "Source",
 	"projects": [],
 	"dependencies": {
-		"https://github.com/paolo-rossi/delphi-jose-jwt": "^v3.0.3"
+		"github.com/paolo-rossi/delphi-jose-jwt": "3.0.2"
 	}
 }

--- a/boss.json
+++ b/boss.json
@@ -1,0 +1,11 @@
+{
+	"name": "FB4D",
+	"description": "The OpenSource Cross-Platform Library for Firebase",
+	"version": "1.3.0",
+	"homepage": "https://www.youtube.com/channel/UC3qSIUzdGqoZA8hcA31X0Og",
+	"mainsrc": "Source",
+	"projects": [],
+	"dependencies": {
+		"https://github.com/paolo-rossi/delphi-jose-jwt": "^v3.0.3"
+	}
+}


### PR DESCRIPTION
Boss is a Dependency manager for Delphi and Lazarus (Windows), this way you can easily import and use modules in your project
It uses semantic versioning to manage which version to use, you can read more here:
https://github.com/HashLoad/boss/
Also, note that Delphi-JOSE-JWT already uses it

Thanks